### PR TITLE
fix: migrate DataFetcher to ETSI JSON endpoint with pagination

### DIFF
--- a/lib/relaton/etsi/data_fetcher.rb
+++ b/lib/relaton/etsi/data_fetcher.rb
@@ -1,6 +1,6 @@
 require "date"
+require "json"
 require "mechanize"
-require "csv"
 require "relaton/core"
 require "relaton/index"
 require_relative "../etsi"
@@ -9,10 +9,12 @@ require_relative "data_parser"
 module Relaton
   module Etsi
     class DataFetcher < Core::DataFetcher
-      SOURCEURL = "https://www.etsi.org/?option=com_standardssearch&view=data&format=csv&includeScope=1&" \
-        "page=1&search=&title=1&etsiNumber=1&content=1&version=0&onApproval=1&published=1&withdrawn=1&" \
-        "historical=1&isCurrent=1&superseded=1&startDate=1988-01-15&endDate=%<date>s&harmonized=0&" \
-        "keyword=&TB=&stdType=&frequency=&mandate=&collection=&sort=1&x=%<timestamp>s".freeze
+      PAGE_SIZE = 50
+
+      SOURCEURL = "https://www.etsi.org/custom/standardssearch/data.php?format=json&includeScope=1&" \
+        "page=%<page>s&search=&title=1&etsiNumber=1&content=1&version=0&onApproval=1&published=1&" \
+        "withdrawn=1&historical=1&isCurrent=1&superseded=1&startDate=1988-01-15&endDate=%<date>s&" \
+        "harmonized=0&keyword=&TB=&stdType=&frequency=&mandate=&collection=&sort=1&x=%<timestamp>s".freeze
 
       def index
         @index ||= Relaton::Index.find_or_create :etsi, file: INDEX_FILE
@@ -28,16 +30,58 @@ module Relaton
       # @param [Object] _source unused, required by superclass interface
       #
       def fetch(_source = nil)
-        time = Time.now
-        date = time.to_date + 1
-        timestamp = (time.to_f * 1000).to_i
-        url = format(SOURCEURL, date: date, timestamp: timestamp)
-        csv = fetch_with_retry(url)
-        CSV.parse(csv, headers: true, col_sep: ";", skip_lines: /sep=;/).each do |row|
-          save DataParser.new(row, @errors).parse
-        end
+        first_page = fetch_page(1)
+        process_records(first_page)
+        fetch_remaining_pages(first_page)
         index.save
         report_errors
+      end
+
+      def fetch_remaining_pages(first_page)
+        total = first_page.first ? first_page.first["total_count"].to_i : 0
+        total_pages = (total / PAGE_SIZE.to_f).ceil
+        (2..total_pages).each do |page|
+          records = fetch_page(page)
+          break if records.empty?
+
+          process_records(records)
+        end
+      end
+
+      def fetch_page(page)
+        date = Time.now.to_date + 1
+        timestamp = (Time.now.to_f * 1000).to_i
+        url = format(SOURCEURL, page: page, date: date, timestamp: timestamp)
+        JSON.parse(fetch_with_retry(url))
+      end
+
+      def process_records(records)
+        records.each do |record|
+          save DataParser.new(normalize(record), @errors).parse
+        end
+      end
+
+      def normalize(record)
+        {
+          "ETSI deliverable" => record["ETSI_DELIVERABLE"],
+          "title" => record["TITLE"],
+          "Details link" => "https://webapp.etsi.org/workprogram/Report_WorkItem.asp?WKI_ID=#{record['wki_id']}",
+          "PDF link" => "https://www.etsi.org/deliver/#{record['EDSpathname']}#{record['EDSPDFfilename']}",
+          "Status" => derive_status(record),
+          "Keywords" => record["Keywords"].to_s,
+          "Technical body" => record["TB"],
+          "Scope" => record["Scope"],
+        }
+      end
+
+      def derive_status(record)
+        return "Withdrawn" if record["ACTION_TYPE"] == "WD"
+
+        code = record["STATUS_CODE"].to_i
+        return "On Approval" if code < 12
+        return "Historical" if code == 13
+
+        "Published"
       end
 
       NETWORK_ERRORS = [

--- a/relaton_etsi.gemspec
+++ b/relaton_etsi.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "csv", "~> 3.0"
   spec.add_dependency "mechanize", "~> 2.8"
   spec.add_dependency "relaton-bib", "~> 2.0.0"
   spec.add_dependency "relaton-core", "~> 0.0.13"

--- a/spec/relaton/etsi/data_fetcher_spec.rb
+++ b/spec/relaton/etsi/data_fetcher_spec.rb
@@ -26,16 +26,79 @@ describe Relaton::Etsi::DataFetcher do
       expect(subject.index).to be_instance_of Relaton::Index::Type
     end
 
-    it "#fetch" do
+    it "#fetch single page" do
       agent = double("mechanize")
-      expect(Mechanize).to receive(:new).and_return agent
-      expect(agent).to receive(:get).with(kind_of(String)).and_return double("page", body: "sep=;\r\n\"id\";\r\n\"12\";\r\n")
+      allow(Mechanize).to receive(:new).and_return agent
+      body = '[{"total_count":"1","wki_id":"73740","TITLE":"T",' \
+             '"ETSI_DELIVERABLE":"ETSI EN 1 V1.0.0 (2024-01)",' \
+             '"STATUS_CODE":"12","ACTION_TYPE":"PU",' \
+             '"EDSpathname":"x/","EDSPDFfilename":"y.pdf",' \
+             '"Scope":"S","TB":"WG","Keywords":"k"}]'
+      expect(agent).to receive(:get).with(kind_of(String)).and_return double("page", body: body)
       data_parser = double "data_parser"
       expect(data_parser).to receive(:parse).and_return :bibitem
-      expect(Relaton::Etsi::DataParser).to receive(:new).with(kind_of(CSV::Row), kind_of(Hash)).and_return data_parser
+      expect(Relaton::Etsi::DataParser).to receive(:new).with(kind_of(Hash), kind_of(Hash)).and_return data_parser
       expect(subject).to receive(:save).with(:bibitem)
       expect(subject.index).to receive(:save)
       subject.fetch
+    end
+
+    it "#fetch paginates by total_count" do
+      agent = double("mechanize")
+      allow(Mechanize).to receive(:new).and_return agent
+      record = '{"total_count":"75","wki_id":"1","ETSI_DELIVERABLE":"ETSI EN 1 V1.0.0 (2024-01)",' \
+               '"STATUS_CODE":"12","ACTION_TYPE":"PU","EDSpathname":"","EDSPDFfilename":"",' \
+               '"TITLE":"T","Scope":"S","TB":"WG","Keywords":"k"}'
+      page1 = "[#{Array.new(50, record).join(',')}]"
+      page2 = "[#{Array.new(25, record).join(',')}]"
+      expect(agent).to receive(:get).with(kind_of(String)).and_return(
+        double("page1", body: page1),
+        double("page2", body: page2),
+      )
+      allow(Relaton::Etsi::DataParser).to receive(:new).and_return double("data_parser", parse: :bibitem)
+      allow(subject).to receive(:save)
+      expect(subject.index).to receive(:save)
+      subject.fetch
+      expect(subject).to have_received(:save).exactly(75).times
+    end
+
+    context "#derive_status" do
+      it "Withdrawn" do
+        expect(subject.send(:derive_status, "ACTION_TYPE" => "WD", "STATUS_CODE" => "12")).to eq "Withdrawn"
+      end
+
+      it "On Approval" do
+        expect(subject.send(:derive_status, "ACTION_TYPE" => "PU", "STATUS_CODE" => "5")).to eq "On Approval"
+      end
+
+      it "Historical" do
+        expect(subject.send(:derive_status, "ACTION_TYPE" => "PU", "STATUS_CODE" => "13")).to eq "Historical"
+      end
+
+      it "Published" do
+        expect(subject.send(:derive_status, "ACTION_TYPE" => "PU", "STATUS_CODE" => "12")).to eq "Published"
+      end
+    end
+
+    it "#normalize maps JSON keys to CSV-compatible keys" do
+      record = {
+        "ETSI_DELIVERABLE" => "ETSI EN 1 V1.0.0 (2024-01)",
+        "TITLE" => "Title",
+        "wki_id" => "73740",
+        "EDSpathname" => "etsi_gr/ZSM/001/",
+        "EDSPDFfilename" => "doc.pdf",
+        "STATUS_CODE" => "12", "ACTION_TYPE" => "PU",
+        "Keywords" => "k1,k2", "TB" => "ZSM", "Scope" => "S"
+      }
+      hash = subject.send(:normalize, record)
+      expect(hash["ETSI deliverable"]).to eq "ETSI EN 1 V1.0.0 (2024-01)"
+      expect(hash["title"]).to eq "Title"
+      expect(hash["Details link"]).to eq "https://webapp.etsi.org/workprogram/Report_WorkItem.asp?WKI_ID=73740"
+      expect(hash["PDF link"]).to eq "https://www.etsi.org/deliver/etsi_gr/ZSM/001/doc.pdf"
+      expect(hash["Status"]).to eq "Published"
+      expect(hash["Keywords"]).to eq "k1,k2"
+      expect(hash["Technical body"]).to eq "ZSM"
+      expect(hash["Scope"]).to eq "S"
     end
 
     it "#save" do


### PR DESCRIPTION
The legacy CSV URL (?option=com_standardssearch&view=data&format=csv) now returns the homepage HTML after ETSI's WordPress migration, breaking the daily crawler. Switch to https://www.etsi.org/custom/standardssearch/data.php?format=json with 50-record pagination driven by total_count, and normalize each JSON record into a hash with the existing CSV-compatible keys so DataParser needs no changes. Status is derived from STATUS_CODE/ACTION_TYPE per the mapping in the ETSI standards-search JS. Drops the unused csv gem dep.